### PR TITLE
Feature/global/swagger/#72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,11 +92,11 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-//tasks.register('copyPrivate', Copy) {
-//    from './sivillage-be_secret/'
-//    include 'application.yml'
-//    into 'src/main/resources/'
-//}
-//
-//processResources.dependsOn copyPrivate
+tasks.register('copyPrivate', Copy) {
+    from './sivillage-be_secret/'
+    include 'application.yml'
+    into 'src/main/resources/'
+}
+
+processResources.dependsOn copyPrivate
 

--- a/src/main/java/com/chicchoc/sivillage/global/config/SwaggerConfig.java
+++ b/src/main/java/com/chicchoc/sivillage/global/config/SwaggerConfig.java
@@ -1,0 +1,44 @@
+package com.chicchoc.sivillage.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+
+        Info info = new Info()
+                .title("SiVillage API")
+                .version("0.01")
+                .description("SiVillage API")
+                .termsOfService("http://swagger.io/terms/");
+
+        // Security Secheme명
+        String jwtSchemeName = "jwtAuth";
+
+        // API
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // SecuritySchemes 설정
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")
+                        .in(SecurityScheme.In.HEADER) //
+                        .name("Authorization"));
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}


### PR DESCRIPTION
### 🐈 연관된 이슈
- close: #72 

### ✅ 개요
- 추후 인증이 필요한 API 테스트시, Swagger에서는 Request Header에 토큰을 넣을 수 없어 테스트가 불가하였음

### 🚀 변화점
- Swagger UI에서 헤더에 토큰을 넣어 요청을 보낼 수 있도록 Config 추가

#### 🖥️ 스크린샷(선택)

- Authorize 버튼이 추가되어 Header에 토큰을 추가할 수 있음
<img width="964" alt="image" src="https://github.com/user-attachments/assets/cac06fa2-af3c-4455-a02c-ed9a20d1f57e">

---
- 기존 인증이 필요한 요청(ex. 리뷰 작성API)을 테스트시,
아래 사진과 같이 인증이 되지 않아 인증 실패 예외 발생
<img width="755" alt="image" src="https://github.com/user-attachments/assets/ef7d469e-d6bc-4913-ae11-816159e4b285">


---
- 헤더에 토큰을 넣어 요청시에는 정상 작성됨 확인하였음
<img width="768" alt="image" src="https://github.com/user-attachments/assets/b5e3dad1-300c-4e68-ab37-1f6b38db5399">



### 🧑‍💻리뷰 요구사항

추후 마이페이지, 주문, 결제 담당하시게 되면 본 PR 참고하셔서 요청할 때 토큰넣어서 테스트 해주심 됩니다.