### PR TITLE
Feature/product/fix filtering/#142

### DIFF
--- a/src/main/java/com/chicchoc/sivillage/domain/product/application/ProductService.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/application/ProductService.java
@@ -1,12 +1,17 @@
 package com.chicchoc.sivillage.domain.product.application;
 
 import com.chicchoc.sivillage.domain.product.dto.in.ProductRequestDto;
-import com.chicchoc.sivillage.domain.product.vo.out.ProductResponseVo;
+import com.chicchoc.sivillage.domain.product.dto.out.ProductOptionResponseDto;
+import com.chicchoc.sivillage.domain.product.dto.out.ProductResponseDto;
 
 import java.util.List;
 
 public interface ProductService {
 
-    List<ProductResponseVo> getFilteredProducts(ProductRequestDto productRequestDto);
+    List<ProductResponseDto> getFilteredProducts(ProductRequestDto productRequestDto);
+
+    Long findProductIdByUuid(String productUuid);
+
+    List<ProductOptionResponseDto> getProductOptions(Long productId);
 
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/domain/Product.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/domain/Product.java
@@ -8,9 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Builder
 @Getter
@@ -34,8 +31,4 @@ public class Product extends BaseEntity {
     @Comment("제품 이름")
     @Column(nullable = false, length = 30)
     private String productName;
-
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<ProductOption> productOptions = new ArrayList<>();
-
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/domain/ProductOption.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/domain/ProductOption.java
@@ -55,5 +55,4 @@ public class ProductOption {
     @Comment("할인가격")
     @Column(nullable = true)
     private Integer discountPrice;
-
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/dto/out/ProductOptionResponseDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/dto/out/ProductOptionResponseDto.java
@@ -34,14 +34,16 @@ public class ProductOptionResponseDto {
 
     public static ProductOptionResponseDto fromEntity(ProductOption productOption) {
         return ProductOptionResponseDto.builder()
+                .productOptionUuid(productOption.getProductOptionUuid())
+                .productId(productOption.getProduct() != null ? productOption.getProduct().getId() : null)
                 .sizeId(productOption.getSizeId())
                 .colorId(productOption.getColorId())
                 .etcOptionId(productOption.getEtcOptionId())
+                .saleStatus(productOption.getSaleStatus() != null ? productOption.getSaleStatus().name() : null)
                 .price(productOption.getPrice())
                 .discountRate(productOption.getDiscountRate())
                 .discountPrice(productOption.getDiscountPrice())
                 .build();
     }
-
 
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/dto/out/ProductResponseDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/dto/out/ProductResponseDto.java
@@ -1,25 +1,37 @@
 package com.chicchoc.sivillage.domain.product.dto.out;
 
+import com.chicchoc.sivillage.domain.product.domain.Product;
 import com.chicchoc.sivillage.domain.product.vo.out.ProductResponseVo;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Builder
 public class ProductResponseDto {
+    private Long productId;
     private String productUuid;
     private String brandUuid;
     private String name;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private List<ProductOptionResponseDto> productOptions;
+
+    public static ProductResponseDto fromEntity(Product product) {
+        return ProductResponseDto.builder()
+                .productId(product.getId())
+                .productUuid(product.getProductUuid())
+                .brandUuid(product.getBrandUuid())
+                .name(product.getProductName())
+                .createdAt(product.getCreatedAt())
+                .updatedAt(product.getUpdatedAt())
+                .build();
+    }
 
     // VO로 변환하는 메소드
     public ProductResponseVo toResponseVo() {
         return ProductResponseVo.builder()
+                .productId(productId)
                 .productUuid(productUuid)
                 .brandUuid(brandUuid)
                 .name(name)

--- a/src/main/java/com/chicchoc/sivillage/domain/product/infrastructure/ProductOptionRepository.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/infrastructure/ProductOptionRepository.java
@@ -3,5 +3,8 @@ package com.chicchoc.sivillage.domain.product.infrastructure;
 import com.chicchoc.sivillage.domain.product.domain.ProductOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
+    List<ProductOption> findByProductId(Long productId);
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/infrastructure/ProductRepository.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/infrastructure/ProductRepository.java
@@ -4,5 +4,8 @@ import com.chicchoc.sivillage.domain.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
+import java.util.Optional;
+
 public interface ProductRepository extends JpaRepository<Product, Long>, QuerydslPredicateExecutor<Product> {
+    Optional<Product> findByProductUuid(String uuid);
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/presentation/ProductController.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/presentation/ProductController.java
@@ -2,16 +2,16 @@ package com.chicchoc.sivillage.domain.product.presentation;
 
 import com.chicchoc.sivillage.domain.product.application.ProductService;
 import com.chicchoc.sivillage.domain.product.dto.in.ProductRequestDto;
+import com.chicchoc.sivillage.domain.product.dto.out.ProductOptionResponseDto;
+import com.chicchoc.sivillage.domain.product.dto.out.ProductResponseDto;
+import com.chicchoc.sivillage.domain.product.vo.out.ProductOptionResponseVo;
 import com.chicchoc.sivillage.domain.product.vo.out.ProductResponseVo;
 import com.chicchoc.sivillage.global.common.entity.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -53,8 +53,27 @@ public class ProductController {
                 .isAscending(isAscending)
                 .build();
 
-        List<ProductResponseVo> products = productService.getFilteredProducts(productRequestDto);
+        List<ProductResponseDto> products = productService.getFilteredProducts(productRequestDto);
 
-        return new BaseResponse<>(products);
+        List<ProductResponseVo> productResponseVos = products.stream()
+                .map(ProductResponseDto::toResponseVo)
+                .toList();
+
+        return new BaseResponse<>(productResponseVos);
+    }
+
+    @Operation(summary = "getProductOptions API", description = "상품 옵션 조회", tags = {"Product"})
+    @GetMapping("/{productUuid}")
+    public BaseResponse<List<ProductOptionResponseVo>> getProduct(@PathVariable String productUuid) {
+
+        // UUID를 사용하여 productId를 찾는다
+        Long productId = productService.findProductIdByUuid(productUuid);
+
+        List<ProductOptionResponseDto> productOptionResponseDtos = productService.getProductOptions(productId);
+
+        List<ProductOptionResponseVo> productOptionResponseVos = productOptionResponseDtos.stream()
+                .map(ProductOptionResponseDto::toResponseVo)
+                .toList();
+        return new BaseResponse<>(productOptionResponseVos);
     }
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/product/vo/out/ProductResponseVo.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/product/vo/out/ProductResponseVo.java
@@ -1,34 +1,18 @@
 package com.chicchoc.sivillage.domain.product.vo.out;
 
-import com.chicchoc.sivillage.domain.product.domain.Product;
-import com.chicchoc.sivillage.domain.product.dto.out.ProductOptionResponseDto;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class ProductResponseVo {
+    private Long productId;
     private String productUuid;
     private String brandUuid;
     private String name;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private List<ProductOptionResponseDto> productOptions;
 
-    public static ProductResponseVo fromEntity(Product product) {
-        return ProductResponseVo.builder()
-                .productUuid(product.getProductUuid())
-                .brandUuid(product.getBrandUuid())
-                .name(product.getProductName())
-                .createdAt(product.getCreatedAt())
-                .updatedAt(product.getUpdatedAt())
-                .productOptions(product.getProductOptions().stream()
-                        .map(option -> ProductOptionResponseDto.fromEntity(option))
-                        .collect(Collectors.toList()))
-                .build();
-    }
 }


### PR DESCRIPTION
### 🐈 연관된 이슈
- close: #142

### ✅ 개요
- 지이이이인짜 최종
- @OneToMany 삭제
- 페이징 처리 문제 해결 (groupby 문을 안쓰고 그냥 불러와서 중복되는 product 처리가 안 됨)
- 기존의 product와 productOption을 다 가져오는 것은 너무 무거움

### 🚀 변화점
-.leftJoin(productOption).on(product.id.eq(productOption.product.id)).leftJoin(productCategory).on(product.id.eq(productCategory.productId)) 로 OneToMany 해결
- 페이징 처리 하고 처리 된 product Id를 반환하고 그걸로 product와 productOption을 찾는 로직 추가

#### 🖥️ 스크린샷


### 🧑‍💻리뷰 요구사항

### PR 게시 전 체크리스트

- [x] 코드가 정상적으로 동작하는지 테스트 완료
- [x] Code Formatting 및 `./gradlew checkstyleMain` 확인
