### PR TITLE
Feat : oAuth2 kakao, naver 로그인/회원가입

### DIFF
--- a/src/main/java/com/chicchoc/sivillage/domain/member/domain/Member.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/member/domain/Member.java
@@ -38,7 +38,7 @@ public class Member extends BaseEntity implements UserDetails { //사용자 인�
     private Long id;
 
     @Comment("회원 UUID")
-    @Column(nullable = false, length = 50, unique = true)
+    @Column(nullable = false, length = 21, unique = true)
     private String uuid;
 
     @Comment("회원 이메일")
@@ -71,7 +71,7 @@ public class Member extends BaseEntity implements UserDetails { //사용자 인�
 
     @Comment("회원 자동 로그인 여부")
     @Column(nullable = false)
-    private boolean isAutoSignIn;
+    private boolean isAutoSignIn = false;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/chicchoc/sivillage/domain/member/domain/OauthProvider.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/member/domain/OauthProvider.java
@@ -1,5 +1,0 @@
-package com.chicchoc.sivillage.domain.member.domain;
-
-public class OauthProvider {
-
-}

--- a/src/main/java/com/chicchoc/sivillage/domain/member/domain/OauthUserList.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/member/domain/OauthUserList.java
@@ -1,5 +1,0 @@
-package com.chicchoc.sivillage.domain.member.domain;
-
-public class OauthUserList {
-
-}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/application/CustomOauth2User.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/application/CustomOauth2User.java
@@ -1,0 +1,46 @@
+package com.chicchoc.sivillage.domain.oauth.application;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class CustomOauth2User implements OAuth2User {
+
+    private String provider;
+    private String userId;
+    private String email;
+    @Getter
+    private String memberUuid;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return Map.of(
+                "provider", provider,
+                "userId", userId,
+                "email", email,
+                "memberUuid", memberUuid
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        // 토큰발급시 claims에 들어갈 이름
+        return this.memberUuid;
+    }
+
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/application/Oauth2UserServiceImpl.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/application/Oauth2UserServiceImpl.java
@@ -1,0 +1,88 @@
+package com.chicchoc.sivillage.domain.oauth.application;
+
+import com.chicchoc.sivillage.domain.member.infrastructure.MemberRepository;
+import com.chicchoc.sivillage.domain.oauth.domain.OauthMember;
+import com.chicchoc.sivillage.domain.oauth.infrastructure.OauthMemberRepository;
+import com.chicchoc.sivillage.global.common.entity.BaseResponseStatus;
+import com.chicchoc.sivillage.global.error.exception.BaseException;
+import com.chicchoc.sivillage.global.jwt.application.JwtTokenProvider;
+import com.chicchoc.sivillage.global.jwt.config.JwtProperties;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class Oauth2UserServiceImpl extends DefaultOAuth2UserService {
+    // oauth2 사용자 정보를 가져오고 인증 객체 생성
+
+    private final OauthMemberRepository oauthMemberRepository; // Oauth 연동 계정 관리
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        // OAuth2User 객체 생성
+        OAuth2User oauth2User = super.loadUser(userRequest);
+
+        // OAuth2User 객체가 없거나 속성이 없는 경우 => 예외 처리
+        if (oauth2User == null || oauth2User.getAttributes() == null) {
+            throw new BaseException(BaseResponseStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        // OAuth2User 객체에서 제공자, ID, 이메일 추출
+        String oauthProvider = userRequest.getClientRegistration().getRegistrationId();
+        String oauthMemberId = getOauthMemberId(oauthProvider, oauth2User);
+        String oauthMemberEmail = getOauthMemberEmail(oauthProvider, oauth2User);
+
+        // ID 또는 이메일이 없는 경우 => 예외 처리
+        if (oauthMemberId == null || oauthMemberEmail == null) {
+            throw new BaseException(BaseResponseStatus.INVALID_OAUTH_INFO);
+        }
+
+        // 연동된 계정이 있는지 확인
+        OauthMember oauthMember = oauthMemberRepository.findByOauthIdAndOauthProvider(oauthMemberId, oauthProvider);
+
+        // 연동된 계정이 없는 경우 => 회원가입 페이지 이동
+        if (oauthMember == null) {
+            return new CustomOauth2User(oauthProvider, oauthMemberId, oauthMemberEmail, "fail");
+        }
+
+        // 연동된 계정이 있는 경우 => 로그인 처리(토큰 발급)
+        String memberUuid = oauthMember.getMember().getUuid();
+        return new CustomOauth2User(oauthProvider, oauthMemberId, oauthMemberEmail, memberUuid);
+    }
+
+    // 사용자 ID 추출 메서드
+    private String getOauthMemberId(String oauthProvider, OAuth2User oauth2User) {
+        if ("kakao".equals(oauthProvider)) {
+            return oauth2User.getAttributes().get("id").toString();
+        } else if ("naver".equals(oauthProvider)) {
+            Map<String, String> responseMap = (Map<String, String>) oauth2User.getAttributes().get("response");
+            return responseMap.get("id");
+        }
+        return null;
+    }
+
+    // 사용자 이메일 추출 메서드
+    private String getOauthMemberEmail(String oauthProvider, OAuth2User oauth2User) {
+        if ("kakao".equals(oauthProvider)) {
+            Map<String, String> kakaoAccount = (Map<String, String>) oauth2User.getAttributes().get("kakao_account");
+            return kakaoAccount.get("email");
+        } else if ("naver".equals(oauthProvider)) {
+            Map<String, String> responseMap = (Map<String, String>) oauth2User.getAttributes().get("response");
+            return responseMap.get("email");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/application/OauthService.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/application/OauthService.java
@@ -1,0 +1,12 @@
+package com.chicchoc.sivillage.domain.oauth.application;
+
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignInRequestDto;
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignUpRequestDto;
+import com.chicchoc.sivillage.global.auth.dto.out.SignInResponseDto;
+
+public interface OauthService {
+
+    SignInResponseDto oauthSignUp(OauthSignUpRequestDto requestDto);
+
+    SignInResponseDto oauthSignIn(OauthSignInRequestDto requestDto);
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/application/OauthServiceImpl.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/application/OauthServiceImpl.java
@@ -1,0 +1,88 @@
+package com.chicchoc.sivillage.domain.oauth.application;
+
+import com.chicchoc.sivillage.domain.member.domain.Member;
+import com.chicchoc.sivillage.domain.member.infrastructure.MemberRepository;
+import com.chicchoc.sivillage.domain.oauth.domain.OauthMember;
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignInRequestDto;
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignUpRequestDto;
+import com.chicchoc.sivillage.domain.oauth.infrastructure.OauthMemberRepository;
+import com.chicchoc.sivillage.global.auth.dto.out.SignInResponseDto;
+import com.chicchoc.sivillage.global.common.entity.BaseResponseStatus;
+import com.chicchoc.sivillage.global.common.generator.NanoIdGenerator;
+import com.chicchoc.sivillage.global.error.exception.BaseException;
+import com.chicchoc.sivillage.global.jwt.application.JwtTokenProvider;
+import com.chicchoc.sivillage.global.jwt.config.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OauthServiceImpl implements OauthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final MemberRepository memberRepository;
+    private final OauthMemberRepository oauthMemberRepository;
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public SignInResponseDto oauthSignUp(OauthSignUpRequestDto requestDto) {
+
+        String uuid = new NanoIdGenerator().generateNanoId();
+
+        // 중복된 이름과 전화번호가 존재할 경우 예외 처리
+        if (memberRepository.existsByNameAndPhone(requestDto.getName(), requestDto.getPhone())) {
+            throw new BaseException(BaseResponseStatus.DUPLICATED_NAME_AND_PHONE);
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+        Member member = requestDto.toEntity(encodedPassword, uuid);
+
+        memberRepository.save(member);
+
+        return oauthSignIn(OauthSignInRequestDto.builder()
+                .email(requestDto.getEmail())
+                .password(requestDto.getPassword())
+                .oauthProvider(requestDto.getOauthProvider())
+                .oauthId(requestDto.getOauthId())
+                .oauthEmail(requestDto.getOauthEmail())
+                .build());
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public SignInResponseDto oauthSignIn(OauthSignInRequestDto requestDto) {
+
+        Member member = memberRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.FAILED_TO_LOGIN));
+
+        Authentication authentication = authenticateMember(member, requestDto.getPassword());
+
+        linkOauthAccount(requestDto.getOauthId(), requestDto.getOauthProvider(), requestDto.getOauthEmail(), member);
+
+        String accessToken = jwtTokenProvider.generateToken(authentication, jwtProperties.getAccessExpireTime());
+        String refreshToken = jwtTokenProvider.generateToken(authentication, jwtProperties.getRefreshExpireTime());
+
+        return new SignInResponseDto(accessToken, refreshToken, member.getUuid());
+    }
+
+    private Authentication authenticateMember(Member member, String password) {
+        return authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(member.getUuid(), password)
+        );
+    }
+
+    private void linkOauthAccount(String oauthId, String oauthProvider, String oauthEmail, Member member) {
+        if (!oauthMemberRepository.existsByOauthIdAndOauthProvider(oauthId, oauthProvider)) {
+            OauthMember oauthMember = new OauthMember(oauthId, oauthProvider, oauthEmail, member);
+            oauthMemberRepository.save(oauthMember);
+        }
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/domain/OauthMember.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/domain/OauthMember.java
@@ -1,0 +1,59 @@
+package com.chicchoc.sivillage.domain.oauth.domain;
+
+import com.chicchoc.sivillage.domain.member.domain.Member;
+import com.chicchoc.sivillage.global.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "member_oauth_connection",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"oauth_id", "oauth_provider"})
+        })
+public class OauthMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "oauth_member_id")
+    private long id;
+
+    @Comment("회원 id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Comment("oauth 제공사")
+    @Column(nullable = false, length = 20)
+    private String oauthProvider;
+
+    @Comment("oauth 회원 ID")
+    @Column(nullable = false)
+    private String oauthId;
+
+    @Comment("oauth 회원 이메일")
+    @Column(nullable = true)
+    private String oauthEmail;
+
+    public OauthMember(String oauthId, String oauthProvider, String oauthEmail, Member member) {
+        super();
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+        this.oauthEmail = oauthEmail;
+        this.member = member;
+
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/in/OauthSignInRequestDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/in/OauthSignInRequestDto.java
@@ -1,0 +1,39 @@
+package com.chicchoc.sivillage.domain.oauth.dto.in;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OauthSignInRequestDto {
+
+    @Email
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+
+    @NotBlank
+    private String oauthId;
+
+    @NotBlank
+    private String oauthProvider;
+
+    private String oauthEmail;
+
+    @Builder
+    public OauthSignInRequestDto(String email, String password, String oauthId, String oauthProvider,
+            String oauthEmail) {
+        this.email = email;
+        this.password = password;
+        this.oauthId = oauthId;
+        this.oauthProvider = oauthProvider;
+        this.oauthEmail = oauthEmail;
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/in/OauthSignUpRequestDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/in/OauthSignUpRequestDto.java
@@ -1,0 +1,55 @@
+package com.chicchoc.sivillage.domain.oauth.dto.in;
+
+import com.chicchoc.sivillage.domain.member.domain.Member;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class OauthSignUpRequestDto {
+
+    @Email
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    private String password;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String phone;
+
+    private String postalCode;
+
+    private String address;
+
+    private LocalDate birth;
+
+    private String oauthId;
+
+    private String oauthProvider;
+
+    private String oauthEmail;
+
+    public Member toEntity(String encodedPassword, String uuid) {
+        return Member.builder()
+                .uuid(uuid)
+                .email(email)
+                .password(encodedPassword)
+                .name(name)
+                .phone(phone)
+                .postalCode(postalCode)
+                .address(address)
+                .birth(birth)
+                .build();
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/handler/OauthFailureHandler.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/handler/OauthFailureHandler.java
@@ -1,0 +1,28 @@
+package com.chicchoc.sivillage.domain.oauth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OauthFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception) throws IOException, ServletException {
+        // 실패 원인을 로그로 남기고, 프론트엔드에서 알 수 있도록 리다이렉트
+        String errorMessage = exception.getMessage();
+        log.error("OAuth2 인증 실패: {}", errorMessage);
+
+        // 인증 실패 페이지로 리다이렉트
+        response.sendRedirect("/auth/oauth/failure?error=" + errorMessage);
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/handler/OauthSuccessHandler.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/handler/OauthSuccessHandler.java
@@ -1,0 +1,57 @@
+package com.chicchoc.sivillage.domain.oauth.handler;
+
+import com.chicchoc.sivillage.domain.oauth.application.CustomOauth2User;
+import com.chicchoc.sivillage.domain.oauth.application.Oauth2UserServiceImpl;
+import com.chicchoc.sivillage.domain.oauth.infrastructure.OauthMemberRepository;
+import com.chicchoc.sivillage.global.jwt.application.JwtTokenProvider;
+import com.chicchoc.sivillage.global.jwt.config.JwtProperties;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OauthSuccessHandler extends SimpleUrlAuthenticationSuccessHandler { // 로그인 성공 핸들러
+
+    private final Oauth2UserServiceImpl oauth2UserService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final OauthMemberRepository oauthMemberRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) throws IOException, ServletException {
+
+        // OAuth2User 객체 생성 맟 연동된 계정 정보 추출
+        CustomOauth2User oauth2User = (CustomOauth2User) authentication.getPrincipal();
+        String oauthMemberId = oauth2User.getAttribute("userId");
+        String provider = oauth2User.getAttribute("provider");
+        String email = oauth2User.getAttribute("email");
+        String memberUuid = oauth2User.getMemberUuid();
+
+        // 연동된 계정이 없을 경우, 프론트엔드로 OAuth 정보 전달 및 리다이렉트
+        if (memberUuid.equals("fail")) {
+            log.info("연동된 계정이 없으므로 프론트로 OAuth 정보 전달.");
+            String redirectUrl = "http://localhost:3000/oauth-link";
+            response.sendRedirect(
+                    redirectUrl + "?oauthId=" + oauthMemberId + "&provider=" + provider + "&email=" + email);
+            return;
+        }
+
+        // 연동된 계정이 있을 경우, JWT 토큰 발급 및 프론트엔드로 전달
+        String accessToken = jwtTokenProvider.generateToken(authentication, jwtProperties.getAccessExpireTime());
+        String refreshToken = jwtTokenProvider.generateToken(authentication, jwtProperties.getRefreshExpireTime());
+
+        response.sendRedirect(
+                "http://localhost:3000/oauth?accessToken=" + accessToken + "&refreshToken=" + refreshToken);
+    }
+
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/infrastructure/OauthMemberRepository.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/infrastructure/OauthMemberRepository.java
@@ -1,0 +1,12 @@
+package com.chicchoc.sivillage.domain.oauth.infrastructure;
+
+import com.chicchoc.sivillage.domain.oauth.domain.OauthMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OauthMemberRepository extends JpaRepository<OauthMember, Long> {
+
+    OauthMember findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
+
+    boolean existsByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
+
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/presentation/OauthController.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/presentation/OauthController.java
@@ -1,0 +1,51 @@
+package com.chicchoc.sivillage.domain.oauth.presentation;
+
+import com.chicchoc.sivillage.domain.oauth.application.OauthService;
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignInRequestDto;
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignUpRequestDto;
+import com.chicchoc.sivillage.global.auth.dto.out.SignInResponseDto;
+import com.chicchoc.sivillage.global.auth.vo.SignInResponseVo;
+import com.chicchoc.sivillage.global.common.entity.BaseResponse;
+import com.chicchoc.sivillage.global.jwt.config.JwtProperties;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Oauth2 관련", description = "소셜로그인/회원가입")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/oauth")
+public class OauthController {
+
+    private final OauthService oauthService;
+    private final JwtProperties jwtProperties;
+
+    @Operation(summary = "회원가입", description = "회원가입 + 로그인(토큰 응답) + 연동")
+    @PostMapping("/sign-up")
+    public BaseResponse<SignInResponseVo> oauthSignUp(@Valid @RequestBody OauthSignUpRequestDto requestDto,
+            HttpServletResponse response) {
+        SignInResponseDto signUpResponse = oauthService.oauthSignUp(requestDto);
+        return sendTokens(signUpResponse, response);
+    }
+
+    @Operation(summary = "로그인 ", description = "로그인(토큰 2종 헤더에 발급) + 연동")
+    @PostMapping("/sign-in")
+    public BaseResponse<SignInResponseVo> oauthSignIn(@Valid @RequestBody OauthSignInRequestDto requestDto,
+            HttpServletResponse response) {
+        SignInResponseDto signInResponse = oauthService.oauthSignIn(requestDto);
+        return sendTokens(signInResponse, response);
+    }
+
+    private BaseResponse<SignInResponseVo> sendTokens(SignInResponseDto responseDto, HttpServletResponse response) {
+        response.setHeader(jwtProperties.getAccessTokenPrefix(), responseDto.getAccessToken());
+        response.setHeader(jwtProperties.getRefreshTokenPrefix(), responseDto.getRefreshToken());
+
+        return new BaseResponse<>(responseDto.toVo());
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/global/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/chicchoc/sivillage/global/auth/application/AuthServiceImpl.java
@@ -107,7 +107,6 @@ public class AuthServiceImpl implements AuthService {
 
     }
 
-    @MethodLoggerAop
     @Transactional(rollbackFor = Exception.class)
     @Override
     public void sendVerificationEmail(EmailVerificationRequestDto requestDto) {

--- a/src/main/java/com/chicchoc/sivillage/global/auth/presentation/AuthController.java
+++ b/src/main/java/com/chicchoc/sivillage/global/auth/presentation/AuthController.java
@@ -72,7 +72,6 @@ public class AuthController {
         return new BaseResponse<>(authService.findEmail(findEmailRequestDto));
     }
 
-    @MethodLoggerAop
     @Operation(summary = "이메일 인증코드 전송", description = "이메일 인증코드 전송")
     @PostMapping("/email-verification")
     public BaseResponse<Void> emailVerification(@Valid @RequestBody EmailVerificationRequestDto requestDto) {

--- a/src/main/java/com/chicchoc/sivillage/global/common/entity/BaseResponse.java
+++ b/src/main/java/com/chicchoc/sivillage/global/common/entity/BaseResponse.java
@@ -26,6 +26,16 @@ public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, Stri
     }
 
     /**
+     * 요청에 실패한 경우. 에러 메시지를 result에 추가할 수 있는 생성자
+     *
+     * @param status 요청 상태
+     * @param result 에러 메시지
+     */
+    public BaseResponse(BaseResponseStatus status, T result) {
+        this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(), result);
+    }
+
+    /**
      * 3. 요청에 실패한 경우.
      *
      * @param status 요청 상태

--- a/src/main/java/com/chicchoc/sivillage/global/common/entity/BaseResponseStatus.java
+++ b/src/main/java/com/chicchoc/sivillage/global/common/entity/BaseResponseStatus.java
@@ -53,6 +53,10 @@ public enum BaseResponseStatus {
     INVALID_EMAIL_ADDRESS(HttpStatus.BAD_REQUEST, false, 2012, "이메일을 다시 확인해주세요."),
     INVALID_EMAIL_CODE_NOT_MATCH(HttpStatus.BAD_REQUEST, false, 2013, "이메일 인증번호가 일치하지 않습니다."),
     INVALID_EMAIL_CODE_EXPIRED(HttpStatus.BAD_REQUEST, false, 2014, "이메일 인증번호가 만료되었습니다."),
+
+    // Oauth
+    NOT_FOUND_OAUTH_MEMBER(HttpStatus.NOT_FOUND, false, 2201, "존재하지 않는 소셜 계정입니다."),
+    INVALID_OAUTH_INFO(HttpStatus.BAD_REQUEST, false, 2202, "소셜 계정 정보가 올바르지 않습니다."),
     //    DUPLICATED_SOCIAL_USER(HttpStatus.CONFLICT, false, 2103, "이미 소셜 연동된 계정입니다."),
     //    DUPLICATED_SOCIAL_PROVIDER_USER(HttpStatus.CONFLICT, false, 2104, "계정에 동일한 플랫폼이 이미 연동되어있습니다."),
     //    PASSWORD_CONTAIN_NUM_FAILED(HttpStatus.BAD_REQUEST, false, 2107, "휴대폰 번호를 포함한 비밀번호입니다."),

--- a/src/main/java/com/chicchoc/sivillage/global/error/exception/BaseExceptionHandler.java
+++ b/src/main/java/com/chicchoc/sivillage/global/error/exception/BaseExceptionHandler.java
@@ -23,11 +23,17 @@ public class BaseExceptionHandler {
      * 발생한 예외 처리.
      */
     @ExceptionHandler(BaseException.class)
-    protected ResponseEntity<BaseResponse<Void>> baseError(BaseException e) {
+    protected ResponseEntity<BaseResponse<String>> baseError(BaseException e) {
 
-        BaseResponse<Void> response = new BaseResponse<>(e.getStatus());
+        // 예외 메시지를 로그에 기록
+        log.error("RuntimeException: ", e.getMessage());
 
-        log.error("예외 발생: {}({}), 값 : {}", e.getStatus(), e.getStatus().getMessage(), e.getMessage());
+        // 예외 스택을 로그에 기록
+        for (StackTraceElement s : e.getStackTrace()) {
+            System.out.println(s);
+        }
+
+        BaseResponse<String> response = new BaseResponse<>(e.getStatus(), e.getMessage());
 
         return new ResponseEntity<>(response, response.httpStatus());
     }
@@ -38,19 +44,19 @@ public class BaseExceptionHandler {
      * @return FAILED_TO_LOGIN 에러 response
      */
     @ExceptionHandler(BadCredentialsException.class)
-    protected ResponseEntity<BaseResponse<Void>> handleBadCredentialsException(BadCredentialsException e) {
+    protected ResponseEntity<BaseResponse<String>> handleBadCredentialsException(BadCredentialsException e) {
 
-        BaseResponse<Void> response = new BaseResponse<>(BaseResponseStatus.FAILED_TO_LOGIN);
-        log.error("BadCredentialsException: ", e);
+        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        log.error("BadCredentialsException: ", e.getMessage());
 
         return new ResponseEntity<>(response, response.httpStatus());
     }
 
     @ExceptionHandler(RuntimeException.class)
-    protected ResponseEntity<BaseResponse<Void>> runtimeError(RuntimeException e) {
+    protected ResponseEntity<BaseResponse<String>> runtimeError(RuntimeException e) {
 
-        BaseResponse<Void> response = new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR);
-        log.error("RuntimeException: ", e);
+        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        log.error("RuntimeException: ", e.getMessage());
 
         for (StackTraceElement s : e.getStackTrace()) {
             System.out.println(s);
@@ -61,10 +67,10 @@ public class BaseExceptionHandler {
 
     // IllegalArgumentException 예외 처리
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<BaseResponse<Void>> handleIllegalArgumentException(
+    public ResponseEntity<BaseResponse<String>> handleIllegalArgumentException(
             IllegalArgumentException e) {
 
-        BaseResponse<Void> response = new BaseResponse<>(BaseResponseStatus.ILLEGAL_ARGUMENT);
+        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.ILLEGAL_ARGUMENT, e.getMessage() );
         log.error("IllegalArgumentException : {}", e.getMessage());
 
         return new ResponseEntity<>(response, response.httpStatus());
@@ -72,9 +78,9 @@ public class BaseExceptionHandler {
 
     // Database 관련 예외 처리
     @ExceptionHandler(DataAccessException.class)
-    public ResponseEntity<BaseResponse<Void>> handleDatabaseException(DataAccessException e) {
+    public ResponseEntity<BaseResponse<String>> handleDatabaseException(DataAccessException e) {
 
-        BaseResponse<Void> response = new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR);
+        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         log.error("DataAccessException : {}", e.getMessage());
 
         return new ResponseEntity<>(response, response.httpStatus());

--- a/src/main/java/com/chicchoc/sivillage/global/error/exception/BaseExceptionHandler.java
+++ b/src/main/java/com/chicchoc/sivillage/global/error/exception/BaseExceptionHandler.java
@@ -46,7 +46,7 @@ public class BaseExceptionHandler {
     @ExceptionHandler(BadCredentialsException.class)
     protected ResponseEntity<BaseResponse<String>> handleBadCredentialsException(BadCredentialsException e) {
 
-        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.FAILED_TO_LOGIN, e.getMessage());
         log.error("BadCredentialsException: ", e.getMessage());
 
         return new ResponseEntity<>(response, response.httpStatus());
@@ -70,7 +70,7 @@ public class BaseExceptionHandler {
     public ResponseEntity<BaseResponse<String>> handleIllegalArgumentException(
             IllegalArgumentException e) {
 
-        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.ILLEGAL_ARGUMENT, e.getMessage() );
+        BaseResponse<String> response = new BaseResponse<>(BaseResponseStatus.ILLEGAL_ARGUMENT, e.getMessage());
         log.error("IllegalArgumentException : {}", e.getMessage());
 
         return new ResponseEntity<>(response, response.httpStatus());


### PR DESCRIPTION
### 🐈 연관된 이슈
- close: #140 

### ✅ 개요
- 소셜로그인 기능 개발

### 🚀 변화점
- 소셜로그인 인증 성공시 Provider에 따른 데이터 파싱
- 이미 연동된 계정이 있는 경우 즉시 토큰 발급
- 연동된 계정이 없는 경우 URL로 oAuth 관련 정보 응답 => 로그인 또는 회원가입 유도
- 회원가입시 회원가입 + 계정 연동 + 토큰발급, 로그인시 계정연동 + 토큰발급
- github Actions Secret 추가 

#### 🖥️ 스크린샷
![image](https://github.com/user-attachments/assets/6ff7b385-1ae9-4b60-ba4c-680be5d9e5d0)


### 🧑‍💻리뷰 요구사항
연휴 + FE에서 테스트 필요한 관계로 리뷰어 할당없이 단독머지 하였습니다.

### PR 게시 전 체크리스트

- [x] 코드가 정상적으로 동작하는지 테스트 완료
- [x] Code Formatting 및 `./gradlew checkstyleMain` 확인
