### PR TITLE
Feat : 약관 응답 수정

### DIFF
--- a/src/main/java/com/chicchoc/sivillage/domain/terms/application/TermsService.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/application/TermsService.java
@@ -1,45 +1,15 @@
 package com.chicchoc.sivillage.domain.terms.application;
 
-import com.chicchoc.sivillage.domain.terms.domain.Terms;
+import com.chicchoc.sivillage.domain.terms.domain.TermsType;
 import com.chicchoc.sivillage.domain.terms.dto.in.CreateTermsRequestDto;
 import com.chicchoc.sivillage.domain.terms.dto.out.TermsResponseDto;
-import com.chicchoc.sivillage.domain.terms.infrastructure.TermsRepository;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor
-@Service
-public class TermsService {
+public interface TermsService {
 
-    private final TermsRepository termsRepository;
+    void createTerms(CreateTermsRequestDto createTermsRequestDto);
 
-    // 약관 생성
-    public void createTerms(CreateTermsRequestDto createTermsRequestDto) {
-        termsRepository.save(createTermsRequestDto.toEntity());
-    }
-
-    // 약관 계층 구조 조회
-    public List<TermsResponseDto> getTermsHierarchy() {
-
-        // view가 true인 약관을 모두 조회
-        List<Terms> terms = termsRepository.findByIsViewTrue();
-
-        // 부모 약관을 기준으로 자식 약관을 매핑
-        Map<Long, List<Terms>> childTermsMap = terms.stream()
-                .filter(term -> Optional.ofNullable(term.getParent()).isPresent())
-                .collect(Collectors.groupingBy(Terms::getParent));
-
-        // 부모 약관을 기준으로 자식 약관을 매핑한 결과를 계층 구조로 변환
-        return terms.stream()
-                .filter(term ->
-                        !Optional.ofNullable(term.getParent()).isPresent())
-                .map(parent ->
-                        new TermsResponseDto(parent, childTermsMap.get(parent.getId())))
-                .collect(Collectors.toList());
-    }
+    Map<TermsType, List<TermsResponseDto>> getTermsHierarchy();
 
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/terms/application/TermsServiceImpl.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/application/TermsServiceImpl.java
@@ -1,0 +1,65 @@
+package com.chicchoc.sivillage.domain.terms.application;
+
+import com.chicchoc.sivillage.domain.terms.domain.Terms;
+import com.chicchoc.sivillage.domain.terms.domain.TermsType;
+import com.chicchoc.sivillage.domain.terms.dto.in.CreateTermsRequestDto;
+import com.chicchoc.sivillage.domain.terms.dto.out.TermsResponseDto;
+import com.chicchoc.sivillage.domain.terms.infrastructure.TermsRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TermsServiceImpl implements TermsService {
+
+    private final TermsRepository termsRepository;
+
+    // 약관 생성
+    public void createTerms(CreateTermsRequestDto createTermsRequestDto) {
+        termsRepository.save(createTermsRequestDto.toEntity());
+    }
+
+    // 약관 조회(마케팅과 이용약관을 필터링하고, 자식 약관을 매핑)
+    public Map<TermsType, List<TermsResponseDto>> getTermsHierarchy() {
+
+        List<Terms> terms = termsRepository.findByIsViewTrue();
+
+        Map<Long, List<Terms>> childTermsMap = mapChildTerms(terms);
+        List<TermsResponseDto> marketingTerms = filterAndMapTerms(terms, TermsType.MARKETING, childTermsMap);
+        List<TermsResponseDto> serviceTerms = filterAndMapTerms(terms, TermsType.SERVICE, childTermsMap);
+
+        return createResponseMap(marketingTerms, serviceTerms);
+    }
+
+    // 자식 약관을 매핑하는 메서드
+    private Map<Long, List<Terms>> mapChildTerms(List<Terms> terms) {
+
+        return terms.stream()
+                .filter(term -> Optional.ofNullable(term.getParent()).isPresent()) // 부모 약관이 있는 경우
+                .collect(Collectors.groupingBy(Terms::getParent)); // 같은 부모를 가진 약관들을 그룹핑
+    }
+
+    // 특정 타입의 약관을 필터링하고, 자식 약관을 매핑하는 메서드
+    private List<TermsResponseDto> filterAndMapTerms(List<Terms> terms, TermsType type,
+            Map<Long, List<Terms>> childTermsMap) {
+        return terms.stream()
+                .filter(term -> term.getType().equals(type)) // Type 별로 필터링
+                .filter(term -> !Optional.ofNullable(term.getParent()).isPresent()) // 최상위 약관만
+                .map(parent -> new TermsResponseDto(parent, childTermsMap.get(parent.getId()))) // 자식 약관 매핑
+                .collect(Collectors.toList()); // 리스트로 변환
+    }
+
+    // 최종적으로 응답할 Map 생성
+    private Map<TermsType, List<TermsResponseDto>> createResponseMap(List<TermsResponseDto> marketingTerms,
+            List<TermsResponseDto> serviceTerms) {
+        Map<TermsType, List<TermsResponseDto>> responseMap = new HashMap<>();
+        responseMap.put(TermsType.MARKETING, marketingTerms);
+        responseMap.put(TermsType.SERVICE, serviceTerms);
+        return responseMap;
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/terms/domain/Terms.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/domain/Terms.java
@@ -1,16 +1,18 @@
 package com.chicchoc.sivillage.domain.terms.domain;
 
-import com.chicchoc.sivillage.domain.member.domain.Member;
 import com.chicchoc.sivillage.global.common.entity.BaseEntity;
-import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -39,16 +41,22 @@ public class Terms extends BaseEntity {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Comment("약관 종류")
+    @Column(name = "type", nullable = false)
+    private TermsType type;
+
     @Comment("view 여부")
     @Column(name = "isview", nullable = false)
     private Boolean isView;
 
     @Builder
-    public Terms(Long parent, Boolean isRequired, String title, String content, Boolean isView) {
+    public Terms(Long parent, Boolean isRequired, String title, String content, TermsType type, Boolean isView) {
         this.parent = parent;
         this.isRequired = isRequired;
         this.title = title;
         this.content = content;
+        this.type = type;
         this.isView = isView;
     }
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/terms/domain/TermsType.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/domain/TermsType.java
@@ -1,0 +1,13 @@
+package com.chicchoc.sivillage.domain.terms.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum TermsType {
+    MARKETING("마케팅"),
+    SERVICE("이용약관");
+
+    private final String type;
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/terms/dto/in/CreateTermsRequestDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/dto/in/CreateTermsRequestDto.java
@@ -1,15 +1,18 @@
 package com.chicchoc.sivillage.domain.terms.dto.in;
 
 import com.chicchoc.sivillage.domain.terms.domain.Terms;
+import com.chicchoc.sivillage.domain.terms.domain.TermsType;
 import lombok.Getter;
 
 @Getter
 public class CreateTermsRequestDto {
+
     private Long parent;
     private Boolean isRequired;
     private String title;
     private String content;
     private Boolean isView;
+    private TermsType type;
 
     public Terms toEntity() {
         return Terms.builder()
@@ -18,6 +21,7 @@ public class CreateTermsRequestDto {
                 .title(title)
                 .content(content)
                 .isView(isView)
+                .type(type)
                 .build();
     }
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/terms/dto/out/TermsResponseDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/dto/out/TermsResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TermsResponseDto {
+
     private Long id;
     private Long parent;
     private Boolean isRequired;
@@ -23,10 +24,9 @@ public class TermsResponseDto {
         this.title = terms.getTitle();
         this.content = terms.getContent();
 
-        // null 체크 후 빈 리스트로 초기화
         if (childTerms != null) {
             for (Terms childTerm : childTerms) {
-                if (childTerm.getParent().equals(terms.getId()) && childTerm != null) {
+                if (childTerm.getParent().equals(terms.getId())) {
                     children.add(new TermsResponseDto(childTerm, childTerms));
                 }
             }

--- a/src/main/java/com/chicchoc/sivillage/domain/terms/presentation/TermsController.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/terms/presentation/TermsController.java
@@ -1,12 +1,14 @@
 package com.chicchoc.sivillage.domain.terms.presentation;
 
 import com.chicchoc.sivillage.domain.terms.application.TermsService;
+import com.chicchoc.sivillage.domain.terms.domain.TermsType;
 import com.chicchoc.sivillage.domain.terms.dto.in.CreateTermsRequestDto;
 import com.chicchoc.sivillage.domain.terms.dto.out.TermsResponseDto;
 import com.chicchoc.sivillage.global.common.entity.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,10 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class TermsController {
 
     private final TermsService termsService;
-    //todo 약관 추가 api
 
-
-    @Operation(summary = "약관 추가", description = "약관 추가(데이터 생성용)")
+    @Operation(summary = "약관 추가(관리자 ONLY)", description = "관리자용 약관데이터 생성")
     @PostMapping("/create")
     public BaseResponse<Void> createTerms(@RequestBody CreateTermsRequestDto createTermsRequestDto) {
 
@@ -33,12 +33,11 @@ public class TermsController {
         return new BaseResponse<>();
     }
 
-    //todo 약관 조회 api(view 상태가 1인 리스트 조회)
-    @Operation(summary = "약관 조회", description = "약관 전체 조회")
+    @Operation(summary = "약관 조회", description = "@Return Map<TermsType, List<Terms>")
     @GetMapping()
-    public BaseResponse<List<TermsResponseDto>> getTerms() {
+    public BaseResponse<Map<TermsType, List<TermsResponseDto>>> getTerms() {
 
-        List<TermsResponseDto> terms = termsService.getTermsHierarchy();
+        Map<TermsType, List<TermsResponseDto>> terms = termsService.getTermsHierarchy();
 
         return new BaseResponse<>(terms);
     }


### PR DESCRIPTION
### 🐈 연관된 이슈
- close: #181 

### ✅ 개요
- 기존 약관의 종류 구분 없이 프론트에게 응답함
- 기존 응답의 경우 프론트에서 하드코딩이 불가피해짐 => 약관 중 마케팅과 이용약관을 구분하여 응답하도록 수정

### 🚀 변화점
- Entity에 TermsType Enum 추가
- 마케팅과 이용약관을 구분하여 응답하도록 수정
- 경우의수가 늘며 코드가 복잡해져 기존 코드 리팩토링 진행

#### 🖥️ 스크린샷
<img width="264" alt="image" src="https://github.com/user-attachments/assets/4d8b18e7-127f-4326-a090-201d834660d8">
<img width="630" alt="image" src="https://github.com/user-attachments/assets/721b4b3d-40bb-4b95-9b35-214eb6e84dec">


### 🧑‍💻리뷰 요구사항

### PR 게시 전 체크리스트

- [x] 코드가 정상적으로 동작하는지 테스트 완료
- [x] Code Formatting 및 `./gradlew checkstyleMain` 확인
