### PR TITLE
Feature/oauth/req/#221

### DIFF
--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/application/OauthService.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/application/OauthService.java
@@ -2,6 +2,9 @@ package com.chicchoc.sivillage.domain.oauth.application;
 
 import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignInRequestDto;
 import com.chicchoc.sivillage.domain.oauth.dto.in.OauthSignUpRequestDto;
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthUserInfoReqestDto;
+import com.chicchoc.sivillage.domain.oauth.dto.out.OauthResponse;
+import com.chicchoc.sivillage.domain.oauth.dto.out.OauthUserInfoResponseDto;
 import com.chicchoc.sivillage.global.auth.dto.out.SignInResponseDto;
 
 public interface OauthService {
@@ -9,4 +12,6 @@ public interface OauthService {
     SignInResponseDto oauthSignUp(OauthSignUpRequestDto requestDto);
 
     SignInResponseDto oauthSignIn(OauthSignInRequestDto requestDto);
+
+    OauthResponse returnUserInfoOrSignIn(OauthUserInfoReqestDto requestDto);
 }

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/in/OauthUserInfoReqestDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/in/OauthUserInfoReqestDto.java
@@ -1,0 +1,31 @@
+package com.chicchoc.sivillage.domain.oauth.dto.in;
+
+import com.chicchoc.sivillage.domain.oauth.dto.out.OauthUserInfoResponseDto;
+import com.chicchoc.sivillage.domain.oauth.vo.in.OauthUserInfoRequestVo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class OauthUserInfoReqestDto {
+
+
+    private String oauthProvider;
+    private String oauthId;
+    private String oauthEmail;
+
+    public static OauthUserInfoReqestDto toDto(OauthUserInfoRequestVo vo) {
+
+        return OauthUserInfoReqestDto.builder()
+                .oauthProvider(vo.getOauthProvider())
+                .oauthId(vo.getOauthId())
+                .oauthEmail(vo.getOauthEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/out/OauthResponse.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/out/OauthResponse.java
@@ -1,0 +1,5 @@
+package com.chicchoc.sivillage.domain.oauth.dto.out;
+
+public interface OauthResponse {
+
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/out/OauthUserInfoResponseDto.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/dto/out/OauthUserInfoResponseDto.java
@@ -1,0 +1,33 @@
+package com.chicchoc.sivillage.domain.oauth.dto.out;
+
+import com.chicchoc.sivillage.domain.oauth.dto.in.OauthUserInfoReqestDto;
+import com.chicchoc.sivillage.domain.oauth.vo.out.OauthUserInfoResponseVo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OauthUserInfoResponseDto implements OauthResponse {
+
+    private String oauthProvider;
+    private String oauthId;
+    private String oauthEmail;
+
+    public OauthUserInfoResponseVo toVo() {
+        return OauthUserInfoResponseVo.builder()
+                .oauthProvider(oauthProvider)
+                .oauthId(oauthId)
+                .oauthEmail(oauthEmail)
+                .build();
+    }
+
+    public static OauthUserInfoResponseDto of(OauthUserInfoReqestDto requestDto) {
+        return OauthUserInfoResponseDto.builder()
+                .oauthProvider(requestDto.getOauthProvider())
+                .oauthId(requestDto.getOauthId())
+                .oauthEmail(requestDto.getOauthEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/infrastructure/OauthMemberRepository.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/infrastructure/OauthMemberRepository.java
@@ -1,11 +1,12 @@
 package com.chicchoc.sivillage.domain.oauth.infrastructure;
 
 import com.chicchoc.sivillage.domain.oauth.domain.OauthMember;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OauthMemberRepository extends JpaRepository<OauthMember, Long> {
 
-    OauthMember findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
+    Optional<OauthMember> findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
 
     boolean existsByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
 

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/vo/in/OauthUserInfoRequestVo.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/vo/in/OauthUserInfoRequestVo.java
@@ -1,0 +1,18 @@
+package com.chicchoc.sivillage.domain.oauth.vo.in;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class OauthUserInfoRequestVo {
+
+    @NotBlank(message = "provider는 필수값입니다.")
+    private String oauthProvider;
+
+    @NotBlank(message = "oAuthId는 필수값입니다.")
+    private String oauthId;
+
+    @Email(message = "이메일 형식이 아닙니다.")
+    private String oauthEmail;
+}

--- a/src/main/java/com/chicchoc/sivillage/domain/oauth/vo/out/OauthUserInfoResponseVo.java
+++ b/src/main/java/com/chicchoc/sivillage/domain/oauth/vo/out/OauthUserInfoResponseVo.java
@@ -1,0 +1,16 @@
+package com.chicchoc.sivillage.domain.oauth.vo.out;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OauthUserInfoResponseVo {
+
+    private String oauthProvider;
+    private String oauthId;
+    private String oauthEmail;
+
+}

--- a/src/main/java/com/chicchoc/sivillage/global/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/chicchoc/sivillage/global/auth/application/AuthServiceImpl.java
@@ -52,7 +52,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public SignInResponseDto signUpAndSignIn(SignUpRequestDto requestDto) {
 
-        String uuid = new NanoIdGenerator().generateNanoId();
+        String uuid =  NanoIdGenerator.generateNanoId();
 
         // 중복된 이름과 전화번호가 존재할 경우 예외 처리
         if (memberRepository.existsByNameAndPhone(requestDto.getName(), requestDto.getPhone())) {

--- a/src/main/java/com/chicchoc/sivillage/global/auth/dto/out/SignInResponseDto.java
+++ b/src/main/java/com/chicchoc/sivillage/global/auth/dto/out/SignInResponseDto.java
@@ -1,5 +1,6 @@
 package com.chicchoc.sivillage.global.auth.dto.out;
 
+import com.chicchoc.sivillage.domain.oauth.dto.out.OauthResponse;
 import com.chicchoc.sivillage.global.auth.vo.SignInResponseVo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class SignInResponseDto {
+public class SignInResponseDto implements OauthResponse {
 
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/com/chicchoc/sivillage/global/data/application/ProductDataService.java
+++ b/src/main/java/com/chicchoc/sivillage/global/data/application/ProductDataService.java
@@ -111,7 +111,7 @@ public class ProductDataService {
             // 하나의 제품에서, 색상 n개, 사이즈 m개를 가지면 n * m개의 제품 옵션을 가짐 => 이중 for문
             for (String color : colors) {
                 for (String size : sizes) {
-                    String productOptUuid = new NanoIdGenerator().generateNanoId();
+                    String productOptUuid = NanoIdGenerator.generateNanoId();
 
                     // Step 4-1. 제품 이미지 저장
                     saveImages(dto.getImages(), productOptUuid);
@@ -190,7 +190,7 @@ public class ProductDataService {
                 // 없으면 새로 저장
                 .orElseGet(() -> {
                     Brand newBrand = brandRepository.save(Brand.builder()
-                            .brandUuid(new NanoIdGenerator().generateNanoId())
+                            .brandUuid(NanoIdGenerator.generateNanoId())
                             .name(dto.getBrandNm() != null ? dto.getBrandNm() : "데이터 넣기 힘듭니다.")
                             .brandIndexLetter(dto.getBrandNm().substring(0, 1))
                             .brandListType("en")

--- a/src/main/java/com/chicchoc/sivillage/global/data/dto/review/ReviewDataRequestDto.java
+++ b/src/main/java/com/chicchoc/sivillage/global/data/dto/review/ReviewDataRequestDto.java
@@ -52,7 +52,7 @@ public class ReviewDataRequestDto {
         return Review.builder()
                 .reviewUuid(productEvalNo)
                 .productUuid(productCode)
-                .userUuid(new NanoIdGenerator().generateNanoId())
+                .userUuid(NanoIdGenerator.generateNanoId())
                 .reviewerEmail(reviewerName.isEmpty() ? "anonymous" : reviewerName)
                 .reviewContent(reviewText)
                 .starPoint(starPoint != null ? starPoint : (byte) ThreadLocalRandom.current().nextInt(0, 6))

--- a/src/test/java/com/chicchoc/sivillage/global/config/jwt/JwtFactory.java
+++ b/src/test/java/com/chicchoc/sivillage/global/config/jwt/JwtFactory.java
@@ -21,7 +21,7 @@ public class JwtFactory { //토큰 생성 클래스
     // 기본 필드값 설정
     private SecretKey secretKey;
 
-    private String subject = new NanoIdGenerator().generateNanoId();
+    private String subject = NanoIdGenerator.generateNanoId();
 
     private Date issuedAt = new Date();
 

--- a/src/test/java/com/chicchoc/sivillage/global/config/jwt/TokenProviderTest.java
+++ b/src/test/java/com/chicchoc/sivillage/global/config/jwt/TokenProviderTest.java
@@ -56,7 +56,7 @@ class TokenProviderTest {
         Member testUser = memberRepository.save(Member.builder()
                 .email(uniqueEmail)
                 .password("testpassword")
-                .uuid(new NanoIdGenerator().generateNanoId())
+                .uuid(NanoIdGenerator.generateNanoId())
                 .name("TestUser")
                 .phone("010-1234-5678")
                 .isAutoSignIn(true)
@@ -121,7 +121,7 @@ class TokenProviderTest {
     void getAuthentication() {
 
         // given : 토큰 생성
-        String userUuid = new NanoIdGenerator().generateNanoId();
+        String userUuid = NanoIdGenerator.generateNanoId();
         String token = JwtFactory.builder()
                 .subject(userUuid)
                 .build()
@@ -139,7 +139,7 @@ class TokenProviderTest {
     void getUserUuId() {
 
         // given : 토큰 생성
-        String userUuid = new NanoIdGenerator().generateNanoId();
+        String userUuid = NanoIdGenerator.generateNanoId();
         String token = JwtFactory.builder()
                 .subject(userUuid)
                 .build()


### PR DESCRIPTION
### 🐈 연관된 이슈
- close: #221 

### ✅ 개요
- oAuth 인증 정보를 받아 자체회원 유무에 따라 응답을 달리 하는 API
- 현재 oAuth API는 BE에서 oAtuh 정보를 받아 처리하고 있으나,
- FE에서는 Next Server에서 oAuth 정보를 받아 처리하고 있음 
- => 해당 정보를 받아 연동상태 체크 후 API

### 🚀 변화점
- API 추가
- 기존 코드 사소한 리팩토링

#### 🖥️ 스크린샷

<img width="529" alt="image" src="https://github.com/user-attachments/assets/d044ba6c-e08f-437e-97a5-f51282259ab9">
미연동시 응답

<img width="528" alt="image" src="https://github.com/user-attachments/assets/7c8dd326-610d-405a-8b55-49bd747de4b5">
연동시 응답

### 🧑‍💻리뷰 요구사항

### PR 게시 전 체크리스트

- [x] 코드가 정상적으로 동작하는지 테스트 완료
- [x] Code Formatting 및 `./gradlew checkstyleMain` 확인
